### PR TITLE
Fix no diff in monorepo

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -26,12 +26,12 @@ export const createNextMinorRelease = async (inputs: Inputs) => {
   await exec.exec('git', ['tag', '-f', majorTag])
 
   if (currentTag !== undefined) {
-    core.info('Checking if the gerenated files are changed')
     const diffNames = await gitDiff(currentTag, nextTag)
     if (!isGeneratedFileChanged(diffNames)) {
       core.info('Nothing to release')
       return
     }
+    core.info('Generated file(s) is changed')
   }
   if (github.context.eventName === 'pull_request') {
     core.warning(`Next release is ${nextTag} but do nothing on pull request`)

--- a/src/create.ts
+++ b/src/create.ts
@@ -27,26 +27,8 @@ export const createNextMinorRelease = async (inputs: Inputs) => {
 
   if (currentTag !== undefined) {
     core.info('Checking if the gerenated files are changed')
-    const code = await exec.exec(
-      'git',
-      [
-        'diff',
-        '--exit-code',
-        currentTag,
-        nextTag,
-        '--',
-        // for polyrepo
-        'dist',
-        'action.yaml',
-        // for monorepo
-        '*/dist',
-        '*/action.yaml',
-      ],
-      {
-        ignoreReturnCode: true,
-      }
-    )
-    if (code === 0) {
+    const diffNames = await gitDiff(currentTag, nextTag)
+    if (!isGeneratedFileChanged(diffNames)) {
       core.info('Nothing to release')
       return
     }
@@ -82,4 +64,27 @@ const findCurrentTag = async (majorTag: string) => {
     ignoreReturnCode: true,
   })
   return tags.filter((tag) => tag != majorTag).pop()
+}
+
+const gitDiff = async (currentTag: string, nextTag: string) => {
+  const diffNames: string[] = []
+  await exec.exec('git', ['diff', '--name-only', currentTag, nextTag, '--'], {
+    listeners: {
+      stdline: (l) => diffNames.push(l.trim()),
+    },
+  })
+  return diffNames
+}
+
+export const isGeneratedFileChanged = (diffNames: string[]): boolean => {
+  for (const diffName of diffNames) {
+    const [parent, child] = diffName.split('/')
+    if (parent === 'dist' || parent === 'action.yaml') {
+      return true
+    }
+    if (child === 'dist' || child === 'action.yaml') {
+      return true
+    }
+  }
+  return false
 }

--- a/tests/create.test.ts
+++ b/tests/create.test.ts
@@ -1,0 +1,39 @@
+import { isGeneratedFileChanged } from '../src/create'
+
+describe('generated file is changed in polyrepo', () => {
+  test('no diff', () => {
+    expect(isGeneratedFileChanged([])).toBe(false)
+  })
+
+  test('action.yaml is changed', () => {
+    const diffNames = ['action.yaml']
+    expect(isGeneratedFileChanged(diffNames)).toBe(true)
+  })
+
+  test('dist is changed', () => {
+    const diffNames = ['dist/index.js']
+    expect(isGeneratedFileChanged(diffNames)).toBe(true)
+  })
+
+  test('nothing to release', () => {
+    const diffNames = ['foo']
+    expect(isGeneratedFileChanged(diffNames)).toBe(false)
+  })
+})
+
+describe('generated file is changed in monorepo', () => {
+  test('action.yaml is changed', () => {
+    const diffNames = ['hello/action.yaml']
+    expect(isGeneratedFileChanged(diffNames)).toBe(true)
+  })
+
+  test('dist is changed', () => {
+    const diffNames = ['hello/dist/index.js']
+    expect(isGeneratedFileChanged(diffNames)).toBe(true)
+  })
+
+  test('nothing to release', () => {
+    const diffNames = ['hello/foo']
+    expect(isGeneratedFileChanged(diffNames)).toBe(false)
+  })
+})


### PR DESCRIPTION
Diff check is not working in monorepo:

```console
Current tag is v1.0.0
Next tag is v1.1.0
/usr/bin/sed -i -E s|^/?dist/?||g .gitignore
/usr/bin/git add .
/usr/bin/git status
On branch main
Your branch is up to date with 'origin/main'.

Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	modified:   .gitignore
	new file:   hello-world/dist/index.js
	new file:   hello-world/dist/index.js.map
	new file:   hello-world/dist/licenses.txt
	new file:   hello-world/dist/sourcemap-register.js

/usr/bin/git config user.name github-actions
/usr/bin/git config user.email github-actions@github.com
/usr/bin/git commit -m Release v1.1.0
[main 0c732f1] Release v1.1.0
 5 files changed, [18](https://github.com/int128/typescript-actions-monorepo/runs/5190459870?check_suite_focus=true#step:6:18)[21](https://github.com/int128/typescript-actions-monorepo/runs/5190459870?check_suite_focus=true#step:6:21) insertions(+), 1 deletion(-)
 create mode 1006[44](https://github.com/int128/typescript-actions-monorepo/runs/5190459870?check_suite_focus=true#step:6:44) hello-world/dist/index.js
 create mode 100644 hello-world/dist/index.js.map
 create mode 100644 hello-world/dist/licenses.txt
 create mode 100644 hello-world/dist/sourcemap-register.js
/usr/bin/git tag v1.1.0
/usr/bin/git tag -f v1
Updated tag 'v1' (was f95470b)
Checking if the gerenated files are changed
/usr/bin/git diff --exit-code v1.0.0 v1.1.0 -- dist action.yaml */dist */action.yaml
Nothing to release
```

https://github.com/int128/typescript-actions-monorepo/runs/5190459870?check_suite_focus=true