### PR TITLE
Fix error if no current tag exists

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -12,8 +12,11 @@ type Inputs = {
 export const createNextRelease = async (inputs: Inputs) => {
   const majorTag = `v${inputs.majorVersion}`
   core.info(`Major tag is ${majorTag}`)
+
+  await exec.exec('git', ['fetch', '--tags', '--prune-tags', '--prune'])
   const currentTag = await findCurrentTag(majorTag)
   core.info(`Current tag is ${currentTag ?? 'not found'}`)
+
   const nextTag = computeNextTag(currentTag, majorTag, inputs.level)
   core.info(`Next tag is ${nextTag}`)
 
@@ -55,8 +58,7 @@ export const createNextRelease = async (inputs: Inputs) => {
   core.info(`Created a release as ${release.html_url}`)
 }
 
-const findCurrentTag = async (majorTag: string) => {
-  await exec.exec('git', ['fetch', '--tags', '--prune-tags', '--prune'])
+export const findCurrentTag = async (majorTag: string): Promise<string | undefined> => {
   const { stdout } = await exec.getExecOutput('git', ['tag', '--list', '--contains', majorTag], {
     ignoreReturnCode: true,
   })

--- a/src/create.ts
+++ b/src/create.ts
@@ -63,9 +63,8 @@ export const findCurrentTag = async (majorTag: string): Promise<string | undefin
     ignoreReturnCode: true,
   })
   return stdout
-    .trim()
     .split(/\n/)
-    .filter((tag) => tag != majorTag)
+    .filter((tag) => tag != '' && tag != majorTag)
     .pop()
 }
 

--- a/tests/create.test.ts
+++ b/tests/create.test.ts
@@ -3,7 +3,7 @@ import * as exec from '@actions/exec'
 
 jest.mock('@actions/exec')
 
-describe('generated file is changed in polyrepo', () => {
+describe('isGeneratedFileChanged', () => {
   test('no diff', () => {
     expect(isGeneratedFileChanged([])).toBe(false)
   })
@@ -29,7 +29,7 @@ describe('generated file is changed in polyrepo', () => {
   })
 })
 
-describe('generated file is changed in monorepo', () => {
+describe('isGeneratedFileChanged for monorepo', () => {
   test('action.yaml is changed', () => {
     const diffNames = ['hello/action.yaml']
     expect(isGeneratedFileChanged(diffNames)).toBe(true)
@@ -51,14 +51,14 @@ describe('generated file is changed in monorepo', () => {
   })
 })
 
-describe('find the current tag', () => {
+describe('findCurrentTag', () => {
   test('exact tag exists', async () => {
     jest.mocked(exec.getExecOutput).mockResolvedValue({ stdout: 'v1.0.0', stderr: '', exitCode: 0 })
     const currentTag = await findCurrentTag('v1')
     expect(currentTag).toBe('v1.0.0')
   })
 
-  test('multiple tags exist', async () => {
+  test('if multiple tags exist, it should return the last one', async () => {
     jest.mocked(exec.getExecOutput).mockResolvedValue({ stdout: 'v1.0.0-pre\nv1.0.0', stderr: '', exitCode: 0 })
     const currentTag = await findCurrentTag('v1')
     expect(currentTag).toBe('v1.0.0')


### PR DESCRIPTION
## Problem to solve
When this action is called just after repository creation, the following error occurs:

```
Preparing the next release
Major tag is v0
/usr/bin/git fetch --tags --prune-tags --prune
/usr/bin/git tag --list --contains v0
error: malformed object name v0
Current tag is 
Error: current tag  is not in form of v0.0.0
```
