### PR TITLE
Remove `.github/workflows` from release tag

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -21,6 +21,8 @@ export const createNextRelease = async (inputs: Inputs) => {
   core.info(`Next tag is ${nextTag}`)
 
   await exec.exec('sed', ['-i', '-E', 's|^/?dist/?||g', '.gitignore'])
+  await exec.exec('rm', ['-fr', '.github/workflows'])
+
   await exec.exec('git', ['add', '.'])
   await exec.exec('git', ['status'])
   await exec.exec('git', ['config', 'user.name', 'github-actions'])

--- a/src/update.ts
+++ b/src/update.ts
@@ -12,6 +12,8 @@ export const followUpCurrentTag = async () => {
   core.info(`Major tag is ${majorTag}`)
 
   await exec.exec('sed', ['-i', '-E', 's|^/?dist/?||g', '.gitignore'])
+  await exec.exec('rm', ['-fr', '.github/workflows'])
+
   await exec.exec('git', ['add', '.'])
   if ((await gitStatus()) === '') {
     core.info(`Current tag is up-to-date`)


### PR DESCRIPTION
If this action is called without workflows permission, it may cause a permission error.

```
 + 5f14dbb...d2d6db7 v0 -> v0 (forced update)
 ! [remote rejected] v0.16.0 -> v0.16.0 (refusing to allow a GitHub App to create or update workflow `.github/workflows/e2e.yaml` without `workflows` permission)
```